### PR TITLE
Make deep-value a proper ES module

### DIFF
--- a/deep-value/tsconfig.json
+++ b/deep-value/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "es6",
     "esModuleInterop": true,
     "declaration": true,
     "target": "es6",


### PR DESCRIPTION
Hi there!

In my project rollup complains about deep-value not being a proper module. I know there are plugins for various module bundlers that allow including a commonjs module (like [@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs)), but IMHO the default should be a proper es6 module.

![Bildschirmfoto 2020-04-25 um 13 18 51](https://user-images.githubusercontent.com/1544760/80278521-64898680-86f7-11ea-8ff7-e576dfdf2937.png)

I assumed your example `import { deepValue } from '@jsier/deep-value';` requires a properly exported function. That's why I changed the module to `es6`.